### PR TITLE
Add support for `coverage debug config`

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -51,6 +51,7 @@ Marc Abramowitz
 Marcus Cobden
 Mark van der Wal
 Martin Fuzzey
+Matthew Boehm
 Matthew Desmarais
 Max Linke
 Mickie Betz

--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -641,7 +641,7 @@ class CoverageScript(object):
         """Implementation of 'coverage debug'."""
 
         if not args:
-            self.help_fn("What information would you like: data, sys?")
+            self.help_fn("What information would you like: config, data, sys?")
             return ERR
 
         for info in args:
@@ -668,6 +668,11 @@ class CoverageScript(object):
                         print(line)
                 else:
                     print("No data collected")
+            elif info == 'config':
+                print(info_header("config"))
+                config_info = self.coverage.config.__dict__.items()
+                for line in info_formatter(config_info):
+                    print(" %s" % line)
             else:
                 self.help_fn("Don't know what you mean by %r" % info)
                 return ERR

--- a/doc/cmd.rst
+++ b/doc/cmd.rst
@@ -415,8 +415,11 @@ command can often help::
 
     $ coverage debug sys > please_attach_to_bug_report.txt
 
-Two types of information are available: ``sys`` to show system configuration,
-and ``data`` to show a summary of the collected coverage data.
+Three types of information are available:
+
+* ``config``: show coverage's configuration
+* ``sys``: show system configuration,
+* ``data``: show a summary of the collected coverage data
 
 
 .. _cmd_run_debug:

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -218,7 +218,7 @@ class CmdLineTest(BaseCmdLineTest):
             """)
 
     def test_debug(self):
-        self.cmd_help("debug", "What information would you like: data, sys?")
+        self.cmd_help("debug", "What information would you like: config, data, sys?")
         self.cmd_help("debug foo", "Don't know what you mean by 'foo'")
 
     def test_debug_sys(self):
@@ -226,6 +226,12 @@ class CmdLineTest(BaseCmdLineTest):
         out = self.stdout()
         self.assertIn("version:", out)
         self.assertIn("data_path:", out)
+
+    def test_debug_config(self):
+        self.command_line("debug config")
+        out = self.stdout()
+        self.assertIn("cover_pylib:", out)
+        self.assertIn("skip_covered:", out)
 
     def test_erase(self):
         # coverage erase


### PR DESCRIPTION
Previously, coverage --debug=config worked, but `coverage debug config` didn't.
Fixes #454