### PR TITLE
#231 on BB: provide more verbose error message

### DIFF
--- a/coverage/python.py
+++ b/coverage/python.py
@@ -51,7 +51,9 @@ def get_python_source(filename):
             break
     else:
         # Couldn't find source.
-        raise NoSource("No source for code: '%s'." % filename)
+        exc_msg = "No source for code: '%s'.\n" % (filename,)
+        exc_msg += "Aborting report output, consider using -i."
+        raise NoSource(exc_msg)
 
     # Replace \f because of http://bugs.python.org/issue19035
     source = source.replace(b'\f', b' ')


### PR DESCRIPTION
In [this issue](https://bitbucket.org/ned/coveragepy/issues/231/various-default-behavior-in-report-phase), there exists an issue where coverage will stop generating an HTML report if the files have been moved out from under it. I didn't see any reason to stop executing, but instead making the exception a little more verbose, reminding the user of -i option which will safely finish the coverage report even if the files have been removed out from under it.