### PR TITLE
Add test case that demonstrates problem #492

### DIFF
--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1021,9 +1021,8 @@ class ProcessCoverageMixin(object):
 class ProcessStartupTest(ProcessCoverageMixin, CoverageTest):
     """Test that we can measure coverage in sub-processes."""
 
-    def test_subprocess_with_pth_files(self):           # pragma: not covered
-        if env.METACOV:
-            self.skip("Can't test sub-process pth file suppport during metacoverage")
+    def setUp(self):
+        super(ProcessStartupTest, self).setUp()
 
         # Main will run sub.py
         self.make_file("main.py", """\
@@ -1036,6 +1035,11 @@ class ProcessStartupTest(ProcessCoverageMixin, CoverageTest):
             with open("out.txt", "w") as f:
                 f.write("Hello, world!\\n")
             """)
+
+    def test_subprocess_with_pth_files(self):           # pragma: not covered
+        if env.METACOV:
+            self.skip("Can't test sub-process pth file suppport during metacoverage")
+
         self.make_file("coverage.ini", """\
             [run]
             data_file = .mycovdata
@@ -1051,6 +1055,28 @@ class ProcessStartupTest(ProcessCoverageMixin, CoverageTest):
         data = coverage.CoverageData()
         data.read_file(".mycovdata")
         self.assertEqual(data.line_counts()['sub.py'], 2)
+
+    def test_subprocess_with_pth_files_and_parallel(self):
+        if env.METACOV:
+            self.skip("Can't test sub-process pth file suppport during metacoverage")
+
+        self.make_file("coverage.ini", """\
+            [run]
+            parallel = true
+            """)
+
+        self.set_environ("COVERAGE_PROCESS_START", "coverage.ini")
+        out = self.run_command("coverage run main.py")
+
+        with open("out.txt") as f:
+            self.assertEqual(f.read(), "Hello, world!\n")
+
+        self.run_command("coverage combine")
+        self.assert_exists(".coverage")
+        data_files = glob.glob(os.getcwd() + '/.coverage*')
+        self.assertEquals(len(data_files), 1,
+            "Expected only .coverage after combine, looks like there are " + \
+            "extra data files that were not cleaned up: %r" % data_files)
 
 
 class ProcessStartupWithSourceTest(ProcessCoverageMixin, CoverageTest):

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1072,7 +1072,14 @@ class ProcessStartupTest(ProcessCoverageMixin, CoverageTest):
             self.assertEqual(f.read(), "Hello, world!\n")
 
         self.run_command("coverage combine")
+
+        # assert that the combined .coverage data file is correct
         self.assert_exists(".coverage")
+        data = coverage.CoverageData()
+        data.read_file(".coverage")
+        self.assertEqual(data.line_counts()['sub.py'], 2)
+
+        # assert that there are *no* extra data files left over after a combine
         data_files = glob.glob(os.getcwd() + '/.coverage*')
         self.assertEquals(len(data_files), 1,
             "Expected only .coverage after combine, looks like there are " + \


### PR DESCRIPTION
Work in progress for the following issue:

https://bitbucket.org/ned/coveragepy/issues/492/subprocess-coverage-strange-detection-of

## Test Case

```bash
(.env) [driti@ubuntu coveragepy]$ nosetests tests/test_process.py:ProcessStartupTest
.F
======================================================================
FAIL: test_subprocess_with_pth_files_and_parallel (tests.test_process.ProcessStartupTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/driti/dev/coveragepy/tests/test_process.py", line 1086, in test_subprocess_with_pth_files_and_parallel
    "extra data files that were not cleaned up: %r" % data_files)
AssertionError: 2 != 1 : Expected only .coverage after combine, looks like there are extra data files that were not cleaned up: ['/tmp/test_cover_89716287/.coverage.ubuntu.115282.482581', '/tmp/test_cover_89716287/.coverage']
-------------------- >> begin captured stdout << ---------------------



--------------------- >> end captured stdout << ----------------------

----------------------------------------------------------------------
Ran 2 tests in 0.656s

FAILED (failures=1)
```