### PR TITLE
Emit a warning when an invalid file is detected with ignore_errors=true.

### DIFF
--- a/coverage/report.py
+++ b/coverage/report.py
@@ -97,5 +97,8 @@ class Reporter(object):
                 # explicitly suppress those errors.
                 # NotPython is only raised by PythonFileReporter, which has a
                 # should_be_python() method.
-                if fr.should_be_python() and not self.config.ignore_errors:
-                    raise
+                if fr.should_be_python(): 
+                    if self.config.ignore_errors:
+                        self.coverage._warn("Could not parse python file {0}".format(fr.filename))
+                    else:
+                        raise

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -194,7 +194,7 @@ supply the "pragma: no cover" regex if you still want to use it.
 measurement is under this value, then exit with a status code of 2.
 
 ``ignore_errors`` (boolean, default False): ignore source code that can't be
-found.
+found, emitting a warning instead of an exception.
 
 ``include`` (multi-string): a list of file name patterns, the files to include
 in reporting.  See :ref:`source` for details.

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -274,6 +274,20 @@ class HtmlWithUnparsableFilesTest(HtmlTestHelpers, CoverageTest):
         self.start_import_stop(cov, "innocuous")
         self.make_file("innocuous.py", "<h1>This isn't python!</h1>")
         cov.html_report(ignore_errors=True)
+        self.assertEqual(
+            len(cov._warnings),
+            1,
+            "Expected a warning to be thrown when an invalid python file is parsed")
+        self.assertIn(
+            "Could not parse python file",
+            cov._warnings[0],
+            "Warning message should be in 'invalid file' warning"
+        )
+        self.assertIn(
+            "innocuous.py",
+            cov._warnings[0],
+            "Filename should be in 'invalid file' warning"
+        )
         self.assert_exists("htmlcov/index.html")
         # This would be better as a glob, if the HTML layout changes:
         self.assert_doesnt_exist("htmlcov/innocuous.html")


### PR DESCRIPTION
Previously, when an invalid file was encountered, it would be silently
ignored.