### PR TITLE
#265: Warn and error out when source and include are both used in coverage run

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -54,6 +54,7 @@ Martin Fuzzey
 Matthew Desmarais
 Max Linke
 Mickie Betz
+Nathan Land
 Noel O'Boyle
 Pablo Carballo
 Patrick Mezard

--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -457,6 +457,11 @@ class CoverageScript(object):
         include = unshell_list(options.include)
         debug = unshell_list(options.debug)
 
+        # Issue #265: When using --source, --include is silently ignored
+        if source and include:
+            self.help_fn("warning: --include arguments are ignored when --source is invoked.")
+            return ERR
+
         # Do something.
         self.coverage = self.covpkg.coverage(
             data_suffix=options.parallel_mode,

--- a/coverage/python.py
+++ b/coverage/python.py
@@ -51,7 +51,9 @@ def get_python_source(filename):
             break
     else:
         # Couldn't find source.
-        raise NoSource("No source for code: '%s'." % filename)
+        exc_msg = "No source for code: '%s'.\n" % (filename,)
+        exc_msg += "Aborting report output, consider using -i."
+        raise NoSource(exc_msg)
 
     # Replace \f because of http://bugs.python.org/issue19035
     source = source.replace(b'\f', b' ')

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -442,6 +442,11 @@ class CmdLineTest(BaseCmdLineTest):
             .save()
             """)
 
+    def test_bad_run_args_with_both_source_and_include(self):
+        self.command_line("run --include=pre1,pre2 --source=lol,wut foo.py", ret=ERR)
+        out = self.stdout()
+        self.assertIn("--include arguments are ignored when --source is invoked.", out)
+
     def test_bad_concurrency(self):
         self.command_line("run --concurrency=nothing", ret=ERR)
         out = self.stdout()


### PR DESCRIPTION
This addresses issue [#265](https://bitbucket.org/ned/coveragepy/issues/265/when-using-source-include-is-silently), and generates a warning message and errors out. Added a test to ensure that it would return a message and error.
