### PR TITLE
Fix integer division inconsistencies between Python 2 and Python 3

### DIFF
--- a/coverage/xmlreport.py
+++ b/coverage/xmlreport.py
@@ -3,6 +3,8 @@
 
 """XML reporting for coverage.py"""
 
+from __future__ import division
+
 import os
 import os.path
 import sys


### PR DESCRIPTION
Another issue flagged by the `-3` flag.

@nedbat There's still some more clean up to do (in third parties as well) and then we'll be able
to keep this clean with CI :D