### PR TITLE
Drop deprecated mid-pattern regex flags

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -95,4 +95,5 @@ Ted Wexler
 Titus Brown
 Ville Skyttä
 Yury Selivanov
+Zac Hatfield-Dodds
 Zooko Wilcox-O'Hearn

--- a/coverage/files.py
+++ b/coverage/files.py
@@ -260,12 +260,9 @@ class FnmatchMatcher(object):
         # Python3.7 fnmatch translates "/" as "/", before that, it translates as "\/",
         # so we have to deal with maybe a backslash.
         fnpats = (re.sub(r"\\?/", r"[\\\\/]", p) for p in fnpats)
-        if env.WINDOWS:
-            # Windows is also case-insensitive.  BTW: the regex docs say that
-            # flags like (?i) have to be at the beginning, but fnmatch puts
-            # them at the end, and having two there seems to work fine.
-            fnpats = (p + "(?i)" for p in fnpats)
-        self.re = re.compile(join_regex(fnpats))
+        # Windows is also case-insensitive, so use the IGNORECASE flag
+        self.re = re.compile(join_regex(fnpats),
+                             flags=re.IGNORECASE if env.WINDOWS else 0)
 
     def __repr__(self):
         return "<FnmatchMatcher %r>" % self.pats


### PR DESCRIPTION
While this does currently work, it also emits DeprecationWarnings which we're trying to treat as errors in HypothesisWorks/hypothesis-python#931.  Using the `re.IGNORECASE` flag when compiling instead of in the pattern sidesteps the whole issue.

@nedbat, I'd particularly appreciate any feedback you can give on when this (or an equivalent change) might be released - our downstream issue will stay open until then, or until I patch out the error if it's going to take a while.  If there's anything I can do to speed this up or otherwise help out, just let me know! 😄 