### PR TITLE
Solved problem with html file names long

### DIFF
--- a/coverage/control.py
+++ b/coverage/control.py
@@ -1058,7 +1058,8 @@ class Coverage(object):
         reporter = AnnotateReporter(self, self.config)
         reporter.report(morfs, directory=directory)
 
-    def html_report(self, morfs=None, directory=None, ignore_errors=None,
+    def html_report(self, morfs=None, directory=None,
+                    source_relative=None, ignore_errors=None,
                     omit=None, include=None, extra_css=None, title=None,
                     skip_covered=None):
         """Generate an HTML report.
@@ -1066,6 +1067,9 @@ class Coverage(object):
         The HTML is written to `directory`.  The file "index.html" is the
         overview starting point, with links to more detailed pages for
         individual modules.
+
+        `source_relative` file names saved in `directory` will be relative to this path,
+        which will result in (C:\\somedir > C:\\somedir\\file.html > file.html)
 
         `extra_css` is a path to a file of other CSS to apply on the page.
         It will be copied into the HTML directory.
@@ -1083,6 +1087,7 @@ class Coverage(object):
             ignore_errors=ignore_errors, report_omit=omit, report_include=include,
             html_dir=directory, extra_css=extra_css, html_title=title,
             skip_covered=skip_covered,
+            source_relative=source_relative
             )
         reporter = HtmlReporter(self, self.config)
         return reporter.report(morfs)

--- a/coverage/files.py
+++ b/coverage/files.py
@@ -106,12 +106,7 @@ def flat_rootname(filename):
 
     """
     name = ntpath.splitdrive(filename)[1]
-    name = re.sub(r"[\\/.:]", "_", name)
-    # On windows, files name too long result in failure to create html file.
-    # Generating an md5 hash should avoid name conflict.
-    if env.WINDOWS and len(name) > 100:
-        name = hashlib.md5(name).hexdigest()
-    return name
+    return re.sub(r"[\\/.:]", "_", name)
 
 
 if env.WINDOWS:

--- a/coverage/html.py
+++ b/coverage/html.py
@@ -66,6 +66,9 @@ def read_data(fname):
 
 def write_html(fname, html):
     """Write `html` to `fname`, properly encoded."""
+    if env.WINDOWS:  # Makes the way safe
+        fname = "\\\\?\\" + os.path.abspath(os.path.normpath(fname))
+
     with open(fname, "wb") as fout:
         fout.write(html.encode('ascii', 'xmlcharrefreplace'))
 
@@ -174,10 +177,11 @@ class HtmlReporter(Reporter):
         """Generate an HTML file for one source file."""
         relative_filename = fr.relative_filename()
 
+        rootname = flat_rootname(relative_filename)
+
+        # Shows relative paths in the browser
         source_relative = getattr(self.config, 'source_relative', None)
         relative_filename = relative_rootname(relative_filename, source_relative)
-
-        rootname = flat_rootname(relative_filename)
 
         html_filename = rootname + ".html"
         html_path = os.path.join(self.directory, html_filename)

--- a/coverage/html.py
+++ b/coverage/html.py
@@ -11,7 +11,7 @@ import shutil
 import coverage
 from coverage import env
 from coverage.backward import iitems
-from coverage.files import flat_rootname
+from coverage.files import flat_rootname, relative_rootname
 from coverage.misc import CoverageException, file_be_gone, Hasher, isolate_module
 from coverage.report import Reporter
 from coverage.results import Numbers
@@ -172,7 +172,13 @@ class HtmlReporter(Reporter):
 
     def html_file(self, fr, analysis):
         """Generate an HTML file for one source file."""
-        rootname = flat_rootname(fr.relative_filename())
+        relative_filename = fr.relative_filename()
+
+        source_relative = getattr(self.config, 'source_relative', None)
+        relative_filename = relative_rootname(relative_filename, source_relative)
+
+        rootname = flat_rootname(relative_filename)
+
         html_filename = rootname + ".html"
         html_path = os.path.join(self.directory, html_filename)
 
@@ -284,12 +290,11 @@ class HtmlReporter(Reporter):
         })
 
         write_html(html_path, html)
-
         # Save this file's information for the index file.
         index_info = {
             'nums': nums,
             'html_filename': html_filename,
-            'relative_filename': fr.relative_filename(),
+            'relative_filename': relative_filename,
         }
         self.files.append(index_info)
         self.status.set_index_info(rootname, index_info)


### PR DESCRIPTION
As reported in the original repository [bitbutcket](https://bitbucket.org/ned/coveragepy/issues/627/failure-generating-html-reports-when-the), worked on the problem and managed to solve it in my environment (windows 10).
I hope it can be useful.