### PR TITLE
Use absolute paths for output directories

### DIFF
--- a/coverage/config.py
+++ b/coverage/config.py
@@ -482,8 +482,8 @@ def read_coverage_config(config_file, **kwargs):
 
     # Once all the config has been collected, there's a little post-processing
     # to do.
-    config.data_file = os.path.expanduser(config.data_file)
-    config.html_dir = os.path.expanduser(config.html_dir)
-    config.xml_output = os.path.expanduser(config.xml_output)
+    config.data_file = os.path.abspath(os.path.expanduser(config.data_file))
+    config.html_dir = os.path.abspath(os.path.expanduser(config.html_dir))
+    config.xml_output = os.path.abspath(os.path.expanduser(config.xml_output))
 
     return config_file, config


### PR DESCRIPTION
This fixes an issue where `coverage` would break when the code under test
called os.chdir, even if the working directory was reset.

Example test failure:
https://phabricator.wikimedia.org/rORESDEPLOYc50b02f9bac3ef6e2a72e7118faea4b47ea0e8fd

Apologies for being too lazy to install BitBucket and Mercurial!