### PR TITLE
Add collector local cache of abs_file

### DIFF
--- a/coverage/collector.py
+++ b/coverage/collector.py
@@ -103,6 +103,7 @@ class Collector(object):
         self.origin = short_stack()
 
         self.concur_id_func = None
+        self.abs_file_cache = {}
 
         # We can handle a few concurrency options here, but only one at a time.
         these_concurrencies = self.SUPPORTED_CONCURRENCIES.intersection(concurrency)
@@ -369,6 +370,13 @@ class Collector(object):
         for tracer in self.tracers:
             tracer.data = data
 
+    def cached_abs_file(self, filename):
+        key = (type(filename), filename)
+        try:
+            return self.abs_file_cache[key]
+        except KeyError:
+            return self.abs_file_cache.setdefault(key, abs_file(filename))
+
     def save_data(self, covdata):
         """Save the collected data to a `CoverageData`.
 
@@ -394,7 +402,7 @@ class Collector(object):
             else:
                 raise runtime_err       # pylint: disable=raising-bad-type
 
-            return dict((abs_file(k), v) for k, v in items)
+            return dict((self.cached_abs_file(k), v) for k, v in items)
 
         if self.branch:
             covdata.add_arcs(abs_file_dict(self.data))


### PR DESCRIPTION
As per [Issue 695](https://bitbucket.org/ned/coveragepy/issues/625/lstat-dominates-in-the-case-of-small), for Hypothesis's weird idiosyncratic usage pattern of coverage, the cost of calling `abs_path` in `save_data` turns out to be quite significant. This implements the simplest possible fix for that, which is that it adds caching to the function.

I wasn't terribly comfortable with adding module-level state, so I implemented a less invasive way of doing this, which is that I added a cache that was local to the collector.

I don't have any great way of benchmarking this, but informally to see the effect of the change I ran one of Hypothesis's test files (`test_testdecorators.py`, which is basically just a smoke test of some typical usage examples). Prior to this change it took about 14 seconds, and after this change it took 11 seconds. Given that most of the time it's spending is probably not in coverage, that's a fairly dramatic improvement!

ETA: On rerunning the same experiment (with the system under slightly different load, so slightly different numbers) I get the following:

* Without using coverage  ~7.5s
* With using coverage and without this change ~13s
* With using coverage and with this change: ~10s.

So for Hypothesis usage at least this change is probably a huge win performance-wise (but I understand Hypothesis usage is weird. Also this is on a system with unusually slow disk access).